### PR TITLE
Fix bugs found when released to the wild

### DIFF
--- a/lib/lita/handlers/forecast/current.rb
+++ b/lib/lita/handlers/forecast/current.rb
@@ -7,6 +7,8 @@ module LitaForecast
   class Current
     include LitaForecast::Mixins
 
+    INFO_UNAVAIL ||= 'Information unavailable. :('
+
     def initialize(forecast)
       @f = forecast
     end
@@ -56,10 +58,14 @@ module LitaForecast
 
     def next_hour
       @f['minutely']['summary']
+    rescue
+      INFO_UNAVAIL
     end
 
     def today
       @f['hourly']['summary']
+    rescue
+      INFO_UNAVAIL
     end
   end
 end

--- a/lib/lita/handlers/forecast/location.rb
+++ b/lib/lita/handlers/forecast/location.rb
@@ -22,10 +22,33 @@ module LitaForecast
         gl = geo_location(g)
         loc = { lat: g['geometry']['location']['lat'],
                 lng: g['geometry']['location']['lng'],
-                desc: "#{gl[:city]}, #{gl[:state]}" }
+                desc: desc(gl) }
       end
 
       loc
+    end
+
+    private
+
+    def desc(loc)
+      l = ''
+      h = { c: city(loc), s: state(loc) }
+      l << h[:c]
+      l << ', ' unless h[:c].empty? || h[:s].empty?
+      l << h[:s]
+      l
+    end
+
+    def city(loc)
+      c = ''
+      c << loc[:city] if loc[:city].is_a?(String) && !loc[:city].empty?
+      c
+    end
+
+    def state(loc)
+      s = ''
+      s << loc[:state] if loc[:state].is_a?(String) && !loc[:state].empty?
+      s
     end
   end
 end

--- a/spec/lita/handlers/forecast/current_spec.rb
+++ b/spec/lita/handlers/forecast/current_spec.rb
@@ -20,7 +20,25 @@ describe LitaForecast::Current do
       'flags' => { 'units' => 'us' }
     }
   end
+  let(:missing_info_forecast) do
+    {
+      'currently' => {
+        'temperature' => 100.11,
+        'apparentTemperature' => 102.11,
+        'summary' => 'weather',
+        'windBearing' => 0,
+        'windSpeed' => 5.11,
+        'humidity' => 0.10,
+        'dewPoint' => 20.11,
+        'pressure' => 1020.11,
+        'cloudCover' => 0.01
+      },
+      'flags' => { 'units' => 'us' }
+    }
+  end
   let(:current) { described_class.new(forecast) }
+  let(:current_no_summary) { described_class.new(missing_info_forecast) }
+  let(:summary_fail) { 'Information unavailable. :(' }
 
   describe '#new' do
     context 'when given more than one arg' do
@@ -48,6 +66,14 @@ describe LitaForecast::Current do
         expect(subject.instance_variable_get(:@f)).to eql forecast
       end
     end
+  end
+
+  describe '::INFO_UNAVAIL' do
+    subject { LitaForecast::Current::INFO_UNAVAIL }
+
+    it { should be_an_instance_of String }
+
+    it { should eql 'Information unavailable. :(' }
   end
 
   describe '.currently' do
@@ -210,13 +236,21 @@ describe LitaForecast::Current do
       end
     end
 
-    context 'when passed no args' do
+    context 'when there is a summary' do
       subject { current.send(:next_hour) }
       let(:next_hour) { 'minutely weather' }
 
       it { should be_an_instance_of String }
 
       it { should eql next_hour }
+    end
+
+    context 'when there is not a summary' do
+      subject { current_no_summary.send(:next_hour) }
+
+      it { should be_an_instance_of String }
+
+      it { should eql summary_fail }
     end
   end
 
@@ -229,13 +263,21 @@ describe LitaForecast::Current do
       end
     end
 
-    context 'when passed no args' do
+    context 'when there is a summary' do
       subject { current.send(:today) }
       let(:today) { 'hourly weather' }
 
       it { should be_an_instance_of String }
 
       it { should eql today }
+    end
+
+    context 'when there is not a summary' do
+      subject { current_no_summary.send(:today) }
+
+      it { should be_an_instance_of String }
+
+      it { should eql summary_fail }
     end
   end
 

--- a/spec/lita/handlers/forecast/location_spec.rb
+++ b/spec/lita/handlers/forecast/location_spec.rb
@@ -65,6 +65,141 @@ describe LitaForecast::Location do
     end
   end
 
+  describe '.city' do
+    context 'when given more than one arg' do
+      it 'should raise ArgumentError' do
+        expect do
+          @lfloc.send(:city, nil, nil)
+        end.to raise_error ArgumentError
+      end
+    end
+
+    context 'when given less than one arg' do
+      it 'should raise ArgumentError' do
+        expect do
+          @lfloc.send(:city)
+        end.to raise_error ArgumentError
+      end
+    end
+
+    context 'when given a location with a city and state' do
+      let(:location) { { city: 'San Francisco', state: 'CA' } }
+      subject { @lfloc.send(:city, location) }
+
+      it { should be_an_instance_of String }
+
+      it { should eql 'San Francisco' }
+    end
+
+    context 'when given a location with a city' do
+      let(:location) { { city: 'San Francisco' } }
+      subject { @lfloc.send(:city, location) }
+
+      it { should be_an_instance_of String }
+
+      it { should eql 'San Francisco' }
+    end
+
+    context 'when given a location without a city' do
+      let(:location) { { state: 'CA' } }
+      subject { @lfloc.send(:city, location) }
+
+      it { should be_an_instance_of String }
+
+      it { should eql '' }
+    end
+  end
+
+  describe '.state' do
+    context 'when given more than one arg' do
+      it 'should raise ArgumentError' do
+        expect do
+          subject.send(:state, nil, nil)
+        end.to raise_error ArgumentError
+      end
+    end
+
+    context 'when given less than one arg' do
+      it 'should raise ArgumentError' do
+        expect do
+          subject.send(:state)
+        end.to raise_error ArgumentError
+      end
+    end
+
+    context 'when given location with a city and a state' do
+      let(:location) { { city: 'San Francisco', state: 'CA' } }
+      subject { @lfloc.send(:state, location) }
+
+      it { should be_an_instance_of String }
+
+      it { should eql 'CA' }
+    end
+
+    context 'when given location with a state' do
+      let(:location) { { state: 'CA' } }
+      subject { @lfloc.send(:state, location) }
+
+      it { should be_an_instance_of String }
+
+      it { should eql 'CA' }
+    end
+
+    context 'when given location with only a city' do
+      let(:location) { { city: 'San Francisco' } }
+      subject { @lfloc.send(:state, location) }
+
+      it { should be_an_instance_of String }
+
+      it { should eql '' }
+    end
+  end
+
+  describe '.desc' do
+    context 'when given more than one arg' do
+      it 'should raise ArgumentError' do
+        expect do
+          @lfloc.send(:desc, nil, nil)
+        end.to raise_error ArgumentError
+      end
+    end
+
+    context 'when given less than one arg' do
+      it 'should raise Argument Error' do
+        expect do
+          @lfloc.send(:desc)
+        end.to raise_error ArgumentError
+      end
+    end
+
+    context 'when provided a location with a city and state' do
+      let(:loc_hash) { { city: 'San Francisco', state: 'CA' } }
+      subject { @lfloc.send(:desc, loc_hash) }
+
+      it { should be_an_instance_of String }
+
+      it { should eql 'San Francisco, CA'}
+    end
+
+    context 'when provided a location with only a state' do
+      let(:loc_hash) { { state: 'CA' } }
+      subject { @lfloc.send(:desc, loc_hash) }
+
+      it { should be_an_instance_of String }
+
+      it { should eql 'CA' }
+    end
+
+    context 'when provided a location with only a city' do
+      let(:loc_hash) { { city: 'San Francisco' } }
+      subject { @lfloc.send(:desc, loc_hash) }
+
+      it { should be_an_instance_of String }
+
+      it { should eql 'San Francisco' }
+    end
+  end
+
   describe '.find_location' do
     before do
       allow_any_instance_of(Geocoder).to receive(:search)


### PR DESCRIPTION
- If the location does not contain a 'City' field, make sure the header format is correct.
- If the weather information contains no hourly forecast, make sure to return a useful error message instead of raising an exception.
- If the weather information contains no daily forecast, make sure to return a useful error message instead of raising an exception.
