### PR TITLE
Update code for compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ rvm:
   - 2.1.1
   - 2.1.0
   - 2.0.0
+sudo: false
+before_install:
+  - gem update bundler

--- a/lib/lita/handlers/forecast.rb
+++ b/lib/lita/handlers/forecast.rb
@@ -11,9 +11,7 @@ module Lita
       include LitaForecast::Mixins
       include LitaForecast::Weather
 
-      def self.default_config(config)
-        config.api_key = nil
-      end
+      config :api_key, required: true
 
       route(
         /^wx\s(.*)$/,

--- a/lib/lita/handlers/forecast/location.rb
+++ b/lib/lita/handlers/forecast/location.rb
@@ -22,16 +22,8 @@ module LitaForecast
 
     def find_location(search)
       loc = lita_redis.hgetall("alias:#{search}").symbolize_keys!
-
-      if loc.empty?
-        g = Geocoder.search(search)[0].data
-        gl = geo_location(g)
-        loc = { lat: g['geometry']['location']['lat'],
-                lng: g['geometry']['location']['lng'],
-                desc: desc(gl) }
-      end
-
-      loc
+      return loc unless loc.empty?
+      geo_search(search)
     end
 
     private
@@ -43,6 +35,14 @@ module LitaForecast
       l << ', ' unless h[:c].empty? || h[:s].empty?
       l << h[:s]
       l
+    end
+
+    def geo_search(search)
+      g = Geocoder.search(search)[0].data
+      gl = geo_location(g)
+      { lat: g['geometry']['location']['lat'],
+        lng: g['geometry']['location']['lng'],
+        desc: desc(gl) }
     end
 
     def name(key, loc)

--- a/lib/lita/handlers/forecast/weather.rb
+++ b/lib/lita/handlers/forecast/weather.rb
@@ -16,8 +16,8 @@ module LitaForecast
     end
 
     def weather(response, api_key, units = 'us')
-      location = LitaForecast::Location.new(LitaForecast.redis)
-        .find_location(response.args.join(' '))
+      location = LitaForecast::Location.new(LitaForecast.redis).find_location(
+        response.args.join(' '))
       f = weather_forecast(api_key, location.merge(params: { units: units }))
       LitaForecast::Response.new(f, location[:desc]).generate
     end

--- a/lib/lita/handlers/forecast_locations.rb
+++ b/lib/lita/handlers/forecast_locations.rb
@@ -35,10 +35,6 @@ module Lita
         }
       )
 
-      def self.default_config(config)
-        config.api_key = nil
-      end
-
       def location_add(response)
         r = response.matches[0]
         return response.reply('Already there!') if alias_exists?(r[0])

--- a/lita-forecast.gemspec
+++ b/lita-forecast.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |g|
   g.add_development_dependency 'simplecov', '~> 0.8.2'
 
   g.add_runtime_dependency 'hashie', '~> 3.0'
-  g.add_runtime_dependency 'lita', '>= 3.0.0'
+  g.add_runtime_dependency 'lita', '>= 4.0.0'
   g.add_runtime_dependency 'forecast_io', '~> 2.0.0'
   g.add_runtime_dependency 'geocoder', '~> 1.1', '>= 1.1.9'
   g.add_runtime_dependency 'compass_rose', '~> 0.1.0'

--- a/lita-forecast.gemspec
+++ b/lita-forecast.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |g|
 
   g.add_development_dependency 'bundler', '~> 1.5'
   g.add_development_dependency 'rake', '~> 10.2'
-  g.add_development_dependency 'rubocop', '~> 0.23.0'
+  g.add_development_dependency 'rubocop', '~> 0.35.0'
   g.add_development_dependency 'rspec', '~> 3.0'
   g.add_development_dependency 'fuubar', '>= 2.0.0.rc1'
   g.add_development_dependency 'coveralls', '~> 0.7.0'

--- a/spec/lita/handlers/forecast_locations_spec.rb
+++ b/spec/lita/handlers/forecast_locations_spec.rb
@@ -3,13 +3,13 @@ require 'spec_helper'
 
 describe Lita::Handlers::ForecastLocations, lita_handler: true do
 
-  it { routes_command('wadd place 42 42').to(:location_add) }
+  it { is_expected.to route_command('wadd place 42 42').to(:location_add) }
 
-  it { routes_command('wadd place 42 42 theplace').to(:location_add) }
+  it { is_expected.to route_command('wadd place 42 42 theplace').to(:location_add) }
 
-  it { routes_command('wrm place').to(:location_rm) }
+  it { is_expected.to route_command('wrm place').to(:location_rm) }
 
-  it { routes_command('wl').to(:locations) }
+  it { is_expected.to route_command('wl').to(:locations) }
 
   describe '.saved_location_hash' do
     context 'when given a description' do

--- a/spec/lita/handlers/forecast_spec.rb
+++ b/spec/lita/handlers/forecast_spec.rb
@@ -6,7 +6,7 @@ describe Lita::Handlers::Forecast, lita_handler: true do
 
   it { is_expected.to route_command('wc sf').to(:weather_ca) }
 
-  describe '#default_config' do
+  describe '#config' do
     it 'should set an empty api key' do
       expect(Lita.config.handlers.forecast.api_key).to be_nil
     end
@@ -64,12 +64,6 @@ describe Lita::Handlers::Forecast, lita_handler: true do
       allow(Lita.config.handlers.forecast).to receive(:api_key)
         .and_return('')
       expect(subject.send(:api_key)).to eql ''
-    end
-  end
-
-  describe '#default_config' do
-    it 'should set the api_key to nil by default' do
-      expect(Lita.config.handlers.forecast.api_key).to be_nil
     end
   end
 end

--- a/spec/lita/handlers/forecast_spec.rb
+++ b/spec/lita/handlers/forecast_spec.rb
@@ -2,9 +2,9 @@
 require 'spec_helper'
 
 describe Lita::Handlers::Forecast, lita_handler: true do
-  it { routes_command('wx sf').to(:weather_us) }
+  it { is_expected.to route_command('wx sf').to(:weather_us) }
 
-  it { routes_command('wc sf').to(:weather_ca) }
+  it { is_expected.to route_command('wc sf').to(:weather_ca) }
 
   describe '#default_config' do
     it 'should set an empty api key' do

--- a/spec/lita/handlers/location_search_spec.rb
+++ b/spec/lita/handlers/location_search_spec.rb
@@ -19,7 +19,7 @@ describe Lita::Handlers::LocationSearch, lita_handler: true do
   end
   let(:ls) { Lita::Handlers::LocationSearch.new('robot') }
 
-  it { routes_command('ws sf').to(:search) }
+  it { is_expected.to route_command('ws sf').to(:search) }
 
   describe '.search_geocoder' do
     context 'when given more than one arg' do

--- a/spec/lita/handlers/location_search_spec.rb
+++ b/spec/lita/handlers/location_search_spec.rb
@@ -81,6 +81,8 @@ describe Lita::Handlers::LocationSearch, lita_handler: true do
   end
 
   describe '.search' do
+    before { allow(described_class).to receive(:new).and_return(subject) }
+
     it 'should return the search response from generate_response' do
       allow(subject)
         .to receive(:generate_response) do |s|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,5 @@ SimpleCov.start do
 end
 
 require 'lita-forecast'
+
+Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
Require lita >= 4.0
Disable lita v3 compatibility mode
Replace default_config with new config syntax
Update spec to pass after lita v4.6.0's spec helper changes
Remove duplicate config test
Miscellaneous sacrifices to appease RuboCop and avoid related parser errors
